### PR TITLE
add options for setup of vue app instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { BaseSchemes, CanAssignSignal, Scope } from 'rete'
 import { RenderPreset } from './presets/types'
 import { getRenderer, Renderer } from './renderer'
 import { Position, RenderSignal } from './types'
+import { Context, Instance } from './vuecompat/types'
 
 export * as Presets from './presets'
 export type { ClassicScheme, VueArea2D } from './presets/classic/types'
@@ -30,7 +31,7 @@ export type Props = {
    *  @param [context] to be used for createApp({ ...context }) or new Vue({ ...context })
    *  @returns app / vue instance.
    */
-  setup?: (context: object) => object;
+  setup?: (context: Context) => Instance;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,18 @@ type Requires<Schemes extends BaseSchemes> =
   | { type: 'unmount', data: { element: HTMLElement } }
 
 /**
+ * Vue plugin options used to setup vue instance(s) used by retejs.
+ */
+export type Props = {
+  /**
+   * Use this to setup vue.
+   *  @param [context] to be used for createApp({ ...context }) or new Vue({ ...context })
+   *  @returns app / vue instance.
+   */
+  setup?: (context: object) => object;
+}
+
+/**
  * Vue plugin. Renders nodes, connections and other elements using React.
  * @priority 9
  * @emits connectionpath
@@ -33,9 +45,9 @@ export class VuePlugin<Schemes extends BaseSchemes, T = Requires<Schemes>> exten
   presets: RenderPreset<Schemes, T>[] = []
   owners = new WeakMap<HTMLElement, RenderPreset<Schemes, T>>()
 
-  constructor() {
+  constructor(props?: Props) {
     super('vue-render')
-    this.renderer = getRenderer()
+    this.renderer = getRenderer(props)
 
     this.addPipe(context => {
       if (!context || typeof context !== 'object' || !('type' in context)) return context

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -2,6 +2,8 @@
 // @ts-ignore
 import { create, destroy, update } from 'process.env.VUECOMPAT'
 
+import { type Props } from './index'
+
 export type Renderer<I> = {
   get(element: Element): I | undefined
   mount<P>(element: Element, vueComponent: any, payload: P, onRendered: any): I
@@ -9,7 +11,7 @@ export type Renderer<I> = {
   unmount(element: Element): void
 }
 
-export function getRenderer<I>(): Renderer<I> {
+export function getRenderer<I>(props?: Props): Renderer<I> {
   const instances = new Map<Element, I>()
 
   return {
@@ -17,7 +19,7 @@ export function getRenderer<I>(): Renderer<I> {
       return instances.get(element)
     },
     mount(element, vueComponent, payload, onRendered) {
-      const app = create(element, vueComponent, payload, onRendered)
+      const app = create(element, vueComponent, payload, onRendered, props)
 
       instances.set(element, app)
 

--- a/src/vuecompat/types.ts
+++ b/src/vuecompat/types.ts
@@ -1,0 +1,11 @@
+import type VueNamespace from 'vue'
+
+type Vue = typeof VueNamespace
+
+export type Context = Vue extends { createApp: (arg: infer U) => any }
+  ? U
+  : (Vue extends { new(options: infer U): any } ? U : any)
+
+export type Instance = Vue extends { createApp: (arg: any) => infer U }
+  ? U
+  : (Vue extends { new(options: any): infer U } ? U : any)

--- a/src/vuecompat/vue2.ts
+++ b/src/vuecompat/vue2.ts
@@ -1,7 +1,9 @@
-import Vue from 'vue'
+import Vue, { ComponentOptions } from 'vue'
 
-export function create(element: any, component: any, payload: any, onRendered: any) {
-  const app = new Vue({
+import { type Props } from './../index'
+
+export function create(element: any, component: any, payload: any, onRendered: any, props?: Props) {
+  const context: ComponentOptions<Vue> & { payload?: Record<string, unknown> } = {
     props: ['payload'],
     render(h) {
       return h(component, { props: { ...this.payload, seed: Math.random() }, ref: 'child' })
@@ -12,7 +14,9 @@ export function create(element: any, component: any, payload: any, onRendered: a
     updated() {
       onRendered()
     }
-  })
+  }
+
+  const app: Vue & { payload?: Record<string, unknown> } = props?.setup ? props.setup(context) as Vue : new Vue(context)
 
   app.payload = payload
 

--- a/src/vuecompat/vue3.ts
+++ b/src/vuecompat/vue3.ts
@@ -2,12 +2,14 @@
 // @ts-ignore
 import { App, createApp, h, markRaw, Ref, ref } from 'vue'
 
+import { type Props } from './../index'
+
 type Instance<P> = { app: App<Element>, payload: Ref<P> }
 
-export function create<P extends object>(element: HTMLElement, component: any, payload: P, onRendered: any): Instance<P> {
+export function create<P extends object>(element: HTMLElement, component: any, payload: P, onRendered: any, props?: Props): Instance<P> {
   const state = ref(markRaw(payload)) as Ref<P>
 
-  const app = createApp({
+  const context = {
     render() {
       // @ts-ignore
       return h(component, { ...state.value, seed: Math.random() })
@@ -18,7 +20,9 @@ export function create<P extends object>(element: HTMLElement, component: any, p
     updated() {
       onRendered()
     }
-  })
+  }
+
+  const app = props?.setup ? props.setup(context) : createApp(context)
 
   app.mount(element)
 


### PR DESCRIPTION
add options to the vue-plugin to allow setup of vue app instance. e.g. for registration of components, plugins...
many frameworks require this type of registration and cant be used otherwise.

usage would look like this:
```
    const render = new VuePlugin<Schemes, AreaExtra>({
        setupVue3: (app) => {
            app.use(i18n); // see https://vue-i18n.intlify.dev/guide/
            app.use(vuetify); // see https://vuetifyjs.com/en/getting-started/installation/
        }
    });
```

i had to make two different methods for vue2 and vue3 to get correct types exported.
so for vue2 it would be setupVue2 ;)